### PR TITLE
add check for big files to ignore symlinks

### DIFF
--- a/src/FileScanner.ts
+++ b/src/FileScanner.ts
@@ -70,7 +70,7 @@ export class FileScanner {
 	}
 
 	private findBigFiles(files: TFile[]) {
-		return files.filter(file => (file.stat.size >> 10) > this.settings.sizeLimitKb);
+		return files.filter(file => (file.stat.size >> 10 && !file.stat.isSymbolicLink()) > this.settings.sizeLimitKb);
 	}
 
 	private findExpired(frontMatters: IFrontMatter[]) {


### PR DESCRIPTION
This change is a small quality-of-life improvement, based on my own habits.

Namely, I like to keep large files out of my vault--that is, files that would be flagged by **Janitor**. However, I sometimes also want to add an embed link that adds that external file to a note, and for that reason, I will symlink that file into my vault.

I do this for a few reasons:

- It's easy to **_link_** to an external file, if you want to open it externally.
  - E.g., `[ext file](/path/to/file/file.pdf)`, and clicking the link opens the default pdf viewer.
- However Obsidian does not enable the user to use a native **_embed link_**, as in `![[/path/to/file/file.pdf]]`.
- There are Obsidian plugins that cover this usage (see [discussion](https://forum.obsidian.md/t/transclude-embed-external-files-audio-videos-pdfs-present-on-the-computer-outside-the-vault/16389)), but I prefer not to introduce external dependencies for an easily solved issue.
  - Example plugins: [oz-image-in-editor-obsidian](https://github.com/ozntel/oz-image-in-editor-obsidian), [obsidian_pdf_oustide_vault](https://github.com/JanPastorek/obsidian_pdf_oustide_vault), [obsidian-external-file-embed-and-link](https://github.com/oylbin/obsidian-external-file-embed-and-link).

The good news this modification is extremely simple, adding less than 1 line to the code, and I don't anticipate any undesired downstream effects.

Also, my thought is that the `findBigFiles()` function is the only one where this check makes sense, and it would be sensible for the `orphan`, `empty`, and `expired` checks to remove such a symlink.

That's all for this PR, and thank you for the super useful plugin!