### PR TITLE
Fix startup scan false positives by waiting for onLayoutReady

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -101,11 +101,13 @@ export default class JanitorPlugin extends Plugin {
 		// 	}
 		// })
 
-		this.app.metadataCache.on("resolved", () => {
-			if (this.settings.runAtStartup && !this.initialScanDone) {
-				this.initialScanDone = true;
-				this.scanFiles();
-			}
+		this.app.workspace.onLayoutReady(() => {
+			this.app.metadataCache.on("resolved", () => {
+				if (this.settings.runAtStartup && !this.initialScanDone) {
+					this.initialScanDone = true;
+					this.scanFiles();
+				}
+			});
 		});
 	}
 


### PR DESCRIPTION
The startup scan was firing on the first `metadataCache resolved` event, 
which can occur before Obsidian has fully initialized the vault index. 
This causes false positives — files that are actually linked get reported 
as orphaned.

Fix: wrap the `resolved` listener inside `onLayoutReady` so it only 
registers after the workspace is ready, ensuring the metadata cache is 
fully populated before scanning.