### PR TITLE
fix: wait for the metadata cache before the startup scan

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -15,6 +15,11 @@ import { FileProcessor } from "src/FileProcessor";
 import moment from "moment";
 
 export default class JanitorPlugin extends Plugin {
+	/** How long the metadata cache must stay quiet before the startup scan runs. */
+	private static readonly CACHE_SETTLE_MS = 2000;
+	/** Upper bound on waiting for the cache, so the scan always eventually runs. */
+	private static readonly CACHE_TIMEOUT_MS = 120000;
+
 	settings: JanitorSettings;
 	statusBarItemEl: HTMLElement;
 	ribbonIconEl: HTMLElement;
@@ -107,18 +112,70 @@ export default class JanitorPlugin extends Plugin {
 
 		this.addSettingTab(new JanitorSettingsTab(this.app, this));
 
-		// this.app.workspace.onLayoutReady(()=>{
-		// 	if (this.settings.runAtStartup) {
-		// 		this.scanFiles();
-		// 	}
-		// })
-
-		this.app.metadataCache.on("resolved", async () => {
-			if (this.settings.runAtStartup && !this.initialScanDone) {
-				this.initialScanDone = true;
-				await this.waitForSyncIfNeeded();
-				this.scanFiles();
+		this.app.workspace.onLayoutReady(() => {
+			if (!this.settings.runAtStartup || this.initialScanDone) {
+				return;
 			}
+			this.initialScanDone = true;
+			void this.runStartupScan();
+		});
+	}
+
+	private async runStartupScan() {
+		await this.waitForSyncIfNeeded();
+		await this.waitForMetadataCache();
+		this.scanFiles();
+	}
+
+	/**
+	 * `metadataCache.on("resolved")` fires every time the cache's work queue
+	 * drains, which happens repeatedly while a large vault is indexed at
+	 * startup. Scanning on the first one reads a half-built `resolvedLinks`,
+	 * so attachments belonging to not-yet-parsed notes are reported as orphans.
+	 *
+	 * Wait until every markdown file has an entry in `resolvedLinks` and the
+	 * cache has then stayed quiet for a moment before letting the scan run.
+	 */
+	private waitForMetadataCache(): Promise<void> {
+		return new Promise((resolve) => {
+			let settleTimer: number | undefined;
+			let timeoutTimer: number | undefined;
+			let settled = false;
+
+			const finish = () => {
+				if (settled) return;
+				settled = true;
+				window.clearTimeout(settleTimer);
+				window.clearTimeout(timeoutTimer);
+				this.app.metadataCache.offref(ref);
+				resolve();
+			};
+
+			// Obsidian keys `resolvedLinks` by every markdown file it has
+			// parsed, so a short count is proof the index is still filling in.
+			const indexIsComplete = () =>
+				Object.keys(this.app.metadataCache.resolvedLinks).length >=
+				this.app.vault.getMarkdownFiles().length;
+
+			const check = () => {
+				window.clearTimeout(settleTimer);
+				if (!indexIsComplete()) return;
+				settleTimer = window.setTimeout(
+					finish,
+					JanitorPlugin.CACHE_SETTLE_MS
+				);
+			};
+
+			const ref = this.app.metadataCache.on("resolved", check);
+			this.registerEvent(ref);
+
+			// Sync or another plugin can keep the cache busy indefinitely.
+			// Scan anyway rather than never running the startup scan at all.
+			timeoutTimer = window.setTimeout(
+				finish,
+				JanitorPlugin.CACHE_TIMEOUT_MS
+			);
+			check();
 		});
 	}
 


### PR DESCRIPTION
## Symptom

Janitor shows attachments as orphans when Obsidian starts. But the notes contain links to these attachments. If you do the scan again with the ribbon icon, Janitor finds no orphans.

## Cause

The startup scan runs at the first `resolved` event of the metadata cache. Obsidian sends this event each time it empties its work queue. Obsidian reads a large vault in many batches. Because of this, the event occurs many times at startup.

At the first event, `resolvedLinks` is not complete. It does not contain the links from the notes that Obsidian did not read. Janitor then shows the attachments of these notes as orphans.

## Fix

The scan starts from `workspace.onLayoutReady()`. Then it waits until these two conditions are true:

1. `resolvedLinks` contains an entry for each markdown file.
2. No `resolved` event occurred in the last 2 seconds.

A limit of 120 seconds stops a wait with no end. Obsidian Sync or a different plugin can keep the cache busy.

The patch also registers the event handler with `registerEvent()`. The plugin then releases the handler when it unloads.

🤖 Generated with [Claude Code](https://claude.com/claude-code)